### PR TITLE
fixed error message for bad .Xresoures filename

### DIFF
--- a/xres2lnk/main.cpp
+++ b/xres2lnk/main.cpp
@@ -46,7 +46,7 @@ int wmain(int argc, wchar_t* argv[])
     std::ifstream in(argv[1], std::ios::in);
     if (!in)
     {
-        std::cerr << "Could not read xresources file '" << argv[1] << "'" << std::endl;
+        std::wcerr << L"Could not read xresources file '" << argv[1] << L"'" << std::endl;
         return errno;
     }
 

--- a/xres2lnk/main.cpp
+++ b/xres2lnk/main.cpp
@@ -42,20 +42,21 @@ int wmain(int argc, wchar_t* argv[])
         return GetLastError();
     }
 
-    // Read xresources file into memory
-    std::ifstream in(argv[1], std::ios::in);
-    if (!in)
-    {
-        std::wcerr << L"Could not read xresources file '" << argv[1] << L"'" << std::endl;
-        return errno;
-    }
+	std::string contents;
+	{
+		// Read xresources file into memory
+		std::ifstream in(argv[1], std::ios::in);
+		if (!in)
+		{
+			std::wcerr << L"Could not read xresources file '" << argv[1] << L"'" << std::endl;
+			return errno;
+		}
 
-    std::string contents;
-    in.seekg(0, std::ios::end);
-    contents.resize(in.tellg());
-    in.seekg(0, std::ios::beg);
-    in.read(&contents[0], contents.size());
-    in.close();
+		std::ostringstream oss;
+		oss << in.rdbuf();
+		in.close();
+		contents = oss.str();
+	}
 
     // Parse xresources file for color info
     auto colorInfo = parse_xresources_file(contents);

--- a/xres2lnk/main.cpp
+++ b/xres2lnk/main.cpp
@@ -7,7 +7,8 @@
 #include <sstream>
 #include "color_info.h"
 
-ColorInfo parse_xresources_file(std::string);
+std::string preprocess_xresources_file(const std::string &);
+ColorInfo parse_xresources_file(const std::string &);
 void set_console_colors(NT_CONSOLE_PROPS&, ColorInfo&);
 
 int wmain(int argc, wchar_t* argv[])
@@ -57,6 +58,8 @@ int wmain(int argc, wchar_t* argv[])
     in.read(&contents[0], contents.size());
     in.close();
 
+	// preprocess xresources file for #defines
+	contents = preprocess_xresources_file(contents);
     // Parse xresources file for color info
     auto colorInfo = parse_xresources_file(contents);
 


### PR DESCRIPTION
fix for:

The error message given for an invalid .Xresources filename, argv[1], doesn't print the filename the user input. Instead, it prints the address of argv[1]. For example:
```
$ xres2lnk.exe /mnt/c/Users/username/.Xresources C:/Users/username/Desktop/Bash.lnk
Could not read xresources file '01328DE4'
```

This fix changes the error message to:
```
$ xres2lnk.exe /mnt/c/Users/username/.Xresources C:/Users/username/Desktop/Bash.lnk
Could not read xresources file '/mnt/c/Users/username/.Xresources'
```