### PR TITLE
Safer stream reading

### DIFF
--- a/xres2lnk/main.cpp
+++ b/xres2lnk/main.cpp
@@ -46,7 +46,7 @@ int wmain(int argc, wchar_t* argv[])
     std::ifstream in(argv[1], std::ios::in);
     if (!in)
     {
-        std::cerr << "Could not read xresources file '" << argv[1] << "'" << std::endl;
+        std::wcerr << L"Could not read xresources file '" << argv[1] << L"'" << std::endl;
         return errno;
     }
 

--- a/xres2lnk/main.cpp
+++ b/xres2lnk/main.cpp
@@ -42,20 +42,21 @@ int wmain(int argc, wchar_t* argv[])
         return GetLastError();
     }
 
-    // Read xresources file into memory
-    std::ifstream in(argv[1], std::ios::in);
-    if (!in)
-    {
-        std::wcerr << L"Could not read xresources file '" << argv[1] << L"'" << std::endl;
-        return errno;
-    }
+	std::string contents;
+	{
+		// Read xresources file into memory
+		std::ifstream in(argv[1], std::ios::in);
+		if (!in)
+		{
+			std::wcerr << L"Could not read xresources file '" << argv[1] << L"'" << std::endl;
+			return errno;
+		}
 
-    std::string contents;
-    in.seekg(0, std::ios::end);
-    contents.resize(in.tellg());
-    in.seekg(0, std::ios::beg);
-    in.read(&contents[0], contents.size());
-    in.close();
+		std::ostringstream oss;
+		oss << in.rdbuf();
+		in.close();
+		contents = oss.str();
+	}
 
     // Parse xresources file for color info
     auto colorInfo = parse_xresources_file(contents);


### PR DESCRIPTION
Makes the intent of reading the file into memory clearer by removing the various positioning and resizing calls and replacing them with writing the ifstream's rdbuf() to an ostringstream. Additionally, all of the operations required for reading the file into memory are scoped together so that the associated objects are cleaned up when the operation completes. The scoping also should make clearer which code is associated with the comment "Read xresources file into memory".