### PR TITLE
#define support in .Xresources files

### DIFF
--- a/xres2lnk/main.cpp
+++ b/xres2lnk/main.cpp
@@ -46,7 +46,7 @@ int wmain(int argc, wchar_t* argv[])
     std::ifstream in(argv[1], std::ios::in);
     if (!in)
     {
-        std::cerr << "Could not read xresources file '" << argv[1] << "'" << std::endl;
+        std::wcerr << L"Could not read xresources file '" << argv[1] << L"'" << std::endl;
         return errno;
     }
 

--- a/xres2lnk/main.cpp
+++ b/xres2lnk/main.cpp
@@ -7,7 +7,8 @@
 #include <sstream>
 #include "color_info.h"
 
-ColorInfo parse_xresources_file(std::string);
+std::string preprocess_xresources_file(const std::string &);
+ColorInfo parse_xresources_file(const std::string &);
 void set_console_colors(NT_CONSOLE_PROPS&, ColorInfo&);
 
 int wmain(int argc, wchar_t* argv[])
@@ -57,6 +58,8 @@ int wmain(int argc, wchar_t* argv[])
     in.read(&contents[0], contents.size());
     in.close();
 
+	// preprocess xresources file for #defines
+	contents = preprocess_xresources_file(contents);
     // Parse xresources file for color info
     auto colorInfo = parse_xresources_file(contents);
 


### PR DESCRIPTION
Many of the base16 .Xresources files contain #define macros. This PR adds a preprocessor step to xres2lnk that processes the #define macros.