### PR TITLE
fixed error message for bad .Xresoures filename

### DIFF
--- a/xres2lnk/main.cpp
+++ b/xres2lnk/main.cpp
@@ -46,7 +46,7 @@ int wmain(int argc, wchar_t* argv[])
     std::ifstream in(argv[1], std::ios::in);
     if (!in)
     {
-        std::cerr << "Could not read xresources file '" << argv[1] << "'" << std::endl;
+        std::wcerr << L"Could not read xresources file '" << argv[1] << L"'" << std::endl;
         return errno;
     }
 


### PR DESCRIPTION
fix for:

The error message given for an invalid .Xresources filename, argv[1], doesn't print the filename the user input. Instead, it prints the address of argv[1]. For example:
```
$ xres2lnk.exe /mnt/c/Users/username/.Xresources C:/Users/username/Desktop/Bash.lnk
Could not read xresources file '01328DE4'
```

This fix changes the error message to:
```
$ xres2lnk.exe /mnt/c/Users/username/.Xresources C:/Users/username/Desktop/Bash.lnk
Could not read xresources file '/mnt/c/Users/username/.Xresources'
```